### PR TITLE
feat(registration): show sold-out notice when registration closed

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -23,6 +23,10 @@
   --color-pink-light: oklch(0.75 0.13 360);
 
   --color-pink-transparent: oklch(0.9 0.08 330 / 0.8);
+
+  --color-red: oklch(0.63 0.24 27);
+  --color-red-transparent: oklch(0.63 0.24 27 / 0.8);
+  --color-red-light: oklch(0.63 0.16 27);
 }
 
 @font-face {

--- a/src/components/Home/HomeHero.svelte
+++ b/src/components/Home/HomeHero.svelte
@@ -26,6 +26,8 @@
       <a href="#mehr" use:scrollTo={"mehr"} class={linkClasses}
         >Mehr erfahren</a
       >
+    {:else}
+      <p class="font-bold">Wir sind leider bereits <span use:Underline={"red"}>ausgebucht.</span></p>
     {/if}
   </div>
 </section>

--- a/src/components/Home/HomePrices.svelte
+++ b/src/components/Home/HomePrices.svelte
@@ -39,6 +39,8 @@
     </div>
     {#if data.registrationOpen}
       <RegisterButton />
+    {:else}
+    <p class="font-bold">Wir sind leider bereits <span use:Underline={"red"}>ausgebucht.</span></p>
     {/if}
 
     <div class="space-y-2">

--- a/src/data.json
+++ b/src/data.json
@@ -1,5 +1,5 @@
 {
-  "registrationOpen": true,
+  "registrationOpen": false,
   "dates": {
     "camp": {
       "start": "2026-08-13",

--- a/src/lib/annotate.ts
+++ b/src/lib/annotate.ts
@@ -1,7 +1,7 @@
 import { annotate } from "rough-notation";
 import type { Action } from "svelte/action";
 
-type AnnotateColor = "green" | "yellow" | "black" | "pink";
+type AnnotateColor = "green" | "yellow" | "black" | "pink" | "red";
 
 // Reuse rough-notation's own types instead of duplicating them.
 type RoughOptions = Parameters<typeof annotate>[1];
@@ -54,15 +54,19 @@ const transparentColor: Record<AnnotateColor, string> = {
   yellow: "var(--color-yellow-transparent)",
   black: "var(--color-black-transparent)",
   pink: "var(--color-pink-transparent)",
+  red: "var(--color-red-transparent)",
 };
 
-export const Underline: Action<HTMLElement> = (node) =>
+export const Underline: Action<HTMLElement, AnnotateColor | undefined> = (
+  node,
+  color = "black",
+) =>
   createAnnotation(node, {
     type: "underline",
     strokeWidth: 2,
     iterations: 4,
     padding: 0,
-    color: "var(--color-black-transparent)",
+    color: transparentColor[color],
     multiline: true,
   });
 


### PR DESCRIPTION
## What changed
- Set `registrationOpen` to `false` — the camp is fully booked.
- Instead of only hiding the register button, the hero and prices sections now show "Wir sind leider bereits ausgebucht."
- Added a red annotation color (`--color-red*` in `app.css`, `red` in `annotate.ts`) and made `Underline` accept an optional color, using red to underline "ausgebucht".

## Why
Communicate the sold-out state clearly rather than leaving a blank space where the register button used to be.

## Notes for reviewers
- `Underline` now takes an optional color param defaulting to `"black"`, so all existing call sites are unaffected.
- `.claude/` (local launch config) was intentionally left uncommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)